### PR TITLE
Introduce `bare` option to omit boilerplate

### DIFF
--- a/main.js
+++ b/main.js
@@ -174,7 +174,6 @@ class MyStack extends TerraformStack {
         if (isHcl2) {
             for (var providername of Object.keys(plandata['provider'])) {
                 compiled += `        new ${tfToCdktfType("_" + providername)}Provider(this, '${providername}', {
-
             ${Object.keys(plandata['provider'][providername]).map(prop => `${prop}: "${plandata['provider'][providername][prop]}"`).join(`,
             `)}
         });
@@ -221,7 +220,7 @@ class MyStack extends TerraformStack {
             value: ${r = resourcename.toLowerCase()}
             });
 
-        `;
+`;
                 }
             }
         }
@@ -232,7 +231,7 @@ class MyStack extends TerraformStack {
             value: ${r = resourcename.toLowerCase()}
         });
 
-        `;
+`;
             }
         }
     }


### PR DESCRIPTION
This will be quite useful when converting snippets like documentation.

Will generate this from [./test.tf](./test.tf)

```ts
        new AwsProvider(this, 'aws', {
                a: "b",
                c: "d",
                region: "us-east-1"
            });

            new DnssimpleProvider(this, 'dnssimple', {
                a: "b",
                c: "d"
            });

            const ubuntu = new Instance(this, 'ubuntu', {
            ami: "ami-0ff8a91507f77f867",
            availabilityZone: "us-east-1a",
            instanceType: "t3.nano",
            tags: [
                {
                    name: "MyInstance"
                }
            ]
        });

        const ubuntu2 = new Instance(this, 'ubuntu2', {
            ami: "ami-0ff8a91507f77f867",
            availabilityZone: "us-east-1a",
            instanceType: "t3.nano",
            tags: [
                {
                    name: "MyInstance2"
                }
            ]
        });

        const reftest = new SsmParameter(this, 'reftest', {
            name: "ExampleInstanceId",
            type: "String",
            value: ubuntu.id
        });
```

The indentation looks a bit weird, not sure if I broke this. 